### PR TITLE
Add missing metadata fields to pyproject.toml

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: patch
+---
+
+Add missing metadata fields to pyproject.toml for improved PyPI discoverability:
+
+- `license` field
+- `keywords` for search
+- `[project.urls]` with links to Homepage, Repository, Issues, and Changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,10 @@ name = "cross-web"
 version = "0.4.0"
 description = "A library for working with web frameworks"
 readme = "README.md"
+license = "MIT"
 authors = [{ name = "Patrick Arminio", email = "patrick.arminio@gmail.com" }]
 requires-python = ">=3.9"
+keywords = ["web", "framework", "http", "request", "response", "asgi", "wsgi"]
 dependencies = [
  "typing-extensions>=4.14.0",
 ]
@@ -15,6 +17,12 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: MIT License",
 ]
+
+[project.urls]
+Homepage = "https://github.com/usecross/cross-web"
+Repository = "https://github.com/usecross/cross-web"
+Issues = "https://github.com/usecross/cross-web/issues"
+Changelog = "https://github.com/usecross/cross-web/releases"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Add `license = "MIT"` field for proper license metadata
- Add `keywords` for improved PyPI discoverability
- Add `[project.urls]` section with Homepage, Repository, Issues, and Changelog links

## Test plan
- [ ] Verify package builds correctly with `uv build` or `hatch build`
- [ ] Check metadata appears correctly with `uv pip show cross-web` after install