### PR TITLE
Implement path params

### DIFF
--- a/src/cross_web/protocols.py
+++ b/src/cross_web/protocols.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from typing import Optional, Protocol, Union
 
-from .request._base import HTTPMethod
+from .request._base import HTTPMethod, PathParams
 
 
 class BaseRequestProtocol(Protocol):
@@ -9,6 +9,9 @@ class BaseRequestProtocol(Protocol):
 
     @property
     def query_params(self) -> Mapping[str, Optional[Union[str, list[str]]]]: ...
+
+    @property
+    def path_params(self) -> PathParams: ...
 
     @property
     def method(self) -> HTTPMethod: ...

--- a/src/cross_web/request/__init__.py
+++ b/src/cross_web/request/__init__.py
@@ -7,7 +7,13 @@ from typing_extensions import Self
 if TYPE_CHECKING:
     from starlette.requests import Request as StarletteRequest
 
-from ._base import AsyncHTTPRequestAdapter, FormData, HTTPMethod, QueryParams
+from ._base import (
+    AsyncHTTPRequestAdapter,
+    FormData,
+    HTTPMethod,
+    PathParams,
+    QueryParams,
+)
 from ._starlette import StarletteRequestAdapter
 from ._testing import TestingRequestAdapter
 
@@ -91,6 +97,11 @@ class AsyncHTTPRequest:
     def query_params(self) -> QueryParams:
         """The query parameters of the request."""
         return self._adapter.query_params
+
+    @property
+    def path_params(self) -> PathParams:
+        """The path parameters of the request."""
+        return self._adapter.path_params
 
     @property
     def headers(self) -> Mapping[str, str]:

--- a/src/cross_web/request/_aiohttp.py
+++ b/src/cross_web/request/_aiohttp.py
@@ -55,6 +55,10 @@ class AiohttpHTTPRequestAdapter(AsyncHTTPRequestAdapter):
     def query_params(self) -> QueryParams:
         return cast(QueryParams, self.request.query.copy())  # type: ignore[attr-defined]
 
+    @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], dict(self.request.match_info))
+
     async def get_body(self) -> bytes:
         if self._form_data is not None:
             return b""

--- a/src/cross_web/request/_base.py
+++ b/src/cross_web/request/_base.py
@@ -8,6 +8,7 @@ HTTPMethod = Literal[
 ]
 
 QueryParams = Mapping[str, Optional[str]]
+PathParams = Mapping[str, Any]
 
 
 @dataclass
@@ -35,6 +36,12 @@ class SyncHTTPRequestAdapter(abc.ABC):
     @abc.abstractmethod
     def query_params(self) -> QueryParams:
         """The query parameters of the request."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def path_params(self) -> PathParams:
+        """The path parameters of the request."""
         raise NotImplementedError
 
     @property
@@ -106,6 +113,12 @@ class AsyncHTTPRequestAdapter(abc.ABC):
     @abc.abstractmethod
     def query_params(self) -> QueryParams:
         """The query parameters of the request."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def path_params(self) -> PathParams:
+        """The path parameters of the request."""
         raise NotImplementedError
 
     @property

--- a/src/cross_web/request/_chalice.py
+++ b/src/cross_web/request/_chalice.py
@@ -17,6 +17,10 @@ class ChaliceHTTPRequestAdapter(SyncHTTPRequestAdapter):
         return self.request.query_params or {}
 
     @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], self.request.uri_params or {})
+
+    @property
     def body(self) -> Union[str, bytes]:
         return self.request.raw_body
 

--- a/src/cross_web/request/_django.py
+++ b/src/cross_web/request/_django.py
@@ -23,6 +23,12 @@ class DjangoHTTPRequestAdapter(SyncHTTPRequestAdapter):
         return cast(QueryParams, self.request.GET.dict())
 
     @property
+    def path_params(self) -> Mapping[str, Any]:
+        if self.request.resolver_match is None:
+            return {}
+        return cast(Mapping[str, Any], self.request.resolver_match.kwargs)
+
+    @property
     def body(self) -> Union[str, bytes]:
         return cast(Union[str, bytes], self.request.body.decode())
 
@@ -70,6 +76,12 @@ class AsyncDjangoHTTPRequestAdapter(AsyncHTTPRequestAdapter):
     @property
     def query_params(self) -> QueryParams:
         return cast(QueryParams, self.request.GET.dict())
+
+    @property
+    def path_params(self) -> Mapping[str, Any]:
+        if self.request.resolver_match is None:
+            return {}
+        return cast(Mapping[str, Any], self.request.resolver_match.kwargs)
 
     @property
     def method(self) -> HTTPMethod:

--- a/src/cross_web/request/_flask.py
+++ b/src/cross_web/request/_flask.py
@@ -23,6 +23,10 @@ class FlaskHTTPRequestAdapter(SyncHTTPRequestAdapter):
         return self.request.args.to_dict()
 
     @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], self.request.view_args or {})
+
+    @property
     def body(self) -> Union[str, bytes]:
         return self.request.data.decode()
 
@@ -68,6 +72,10 @@ class AsyncFlaskHTTPRequestAdapter(AsyncHTTPRequestAdapter):
     @property
     def query_params(self) -> QueryParams:
         return self.request.args.to_dict()
+
+    @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], self.request.view_args or {})
 
     @property
     def method(self) -> HTTPMethod:

--- a/src/cross_web/request/_litestar.py
+++ b/src/cross_web/request/_litestar.py
@@ -17,6 +17,10 @@ class LitestarRequestAdapter(AsyncHTTPRequestAdapter):
         return self.request.query_params
 
     @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], self.request.path_params)
+
+    @property
     def method(self) -> HTTPMethod:
         return cast("HTTPMethod", self.request.method.upper())
 

--- a/src/cross_web/request/_quart.py
+++ b/src/cross_web/request/_quart.py
@@ -17,6 +17,10 @@ class QuartHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         return self.request.args.to_dict()
 
     @property
+    def path_params(self) -> Mapping[str, str]:
+        return cast(Mapping[str, str], self.request.view_args or {})
+
+    @property
     def method(self) -> HTTPMethod:
         return cast("HTTPMethod", self.request.method.upper())
 

--- a/src/cross_web/request/_sanic.py
+++ b/src/cross_web/request/_sanic.py
@@ -53,6 +53,10 @@ class SanicHTTPRequestAdapter(AsyncHTTPRequestAdapter):
         return {k: args.get(k, None) for k in args}
 
     @property
+    def path_params(self) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], self.request.match_info or {})
+
+    @property
     def method(self) -> HTTPMethod:
         return cast("HTTPMethod", self.request.method.upper())
 

--- a/src/cross_web/request/_starlette.py
+++ b/src/cross_web/request/_starlette.py
@@ -25,6 +25,10 @@ class StarletteRequestAdapter(AsyncHTTPRequestAdapter):
         return cast(QueryParams, self._request.query_params)
 
     @property
+    def path_params(self) -> Mapping[str, str]:
+        return cast(Mapping[str, str], self._request.path_params)
+
+    @property
     def headers(self) -> Mapping[str, str]:
         # Cache the immutable headers object for direct access
         # Starlette Headers are case-insensitive

--- a/src/cross_web/request/_testing.py
+++ b/src/cross_web/request/_testing.py
@@ -14,6 +14,7 @@ class TestingRequestAdapter(AsyncHTTPRequestAdapter):
         *,
         method: HTTPMethod = "POST",
         query_params: QueryParams | None = None,
+        path_params: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
         content_type: str | None = None,
         url: str = "http://testserver/",
@@ -23,6 +24,7 @@ class TestingRequestAdapter(AsyncHTTPRequestAdapter):
     ) -> None:
         self._method = method
         self._query_params = query_params or {}
+        self._path_params = path_params or {}
         self._headers = headers or {}
         self._content_type = content_type
         self._url = url
@@ -37,6 +39,10 @@ class TestingRequestAdapter(AsyncHTTPRequestAdapter):
     @property
     def query_params(self) -> QueryParams:
         return self._query_params
+
+    @property
+    def path_params(self) -> Mapping[str, Any]:
+        return self._path_params
 
     @property
     def headers(self) -> Mapping[str, str]:

--- a/src/cross_web/testing/clients/django.py
+++ b/src/cross_web/testing/clients/django.py
@@ -3,17 +3,30 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from json import dumps
 from typing import Any
+from urllib.parse import urlsplit
 
 from django.core.exceptions import BadRequest, SuspiciousOperation
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import Http404, HttpRequest, HttpResponse, StreamingHttpResponse
 from django.test.client import AsyncRequestFactory, RequestFactory
+from django.urls import Resolver404, ResolverMatch, resolve
 
 from .base import HttpClient, RequestData, Response, UploadedFile, merge_cookies
 
 
+def resolve_view_match(view: object, url: str) -> ResolverMatch | None:
+    urlpatterns = getattr(view, "_cross_web_urlpatterns", None)
+    if urlpatterns is None:
+        return None
+
+    try:
+        return resolve(urlsplit(url).path, urlconf=tuple(urlpatterns))
+    except Resolver404:
+        return None
+
+
 class DjangoHttpClient(HttpClient):
-    def __init__(self, view: Callable[[HttpRequest], HttpResponse]) -> None:
+    def __init__(self, view: Callable[..., HttpResponse]) -> None:
         self.view = view
 
     def _to_django_headers(self, headers: Mapping[str, str]) -> dict[str, str]:
@@ -60,7 +73,15 @@ class DjangoHttpClient(HttpClient):
 
     async def _do_request(self, request: HttpRequest) -> Response:
         try:
-            response = self.view(request)
+            resolver_match = request.resolver_match
+            if resolver_match is None:
+                response = self.view(request)
+            else:
+                response = self.view(
+                    request,
+                    *resolver_match.args,
+                    **resolver_match.kwargs,
+                )
         except Http404:
             return Response(status_code=404, data=b"Not found")
         except (BadRequest, SuspiciousOperation) as exc:
@@ -98,6 +119,7 @@ class DjangoHttpClient(HttpClient):
         request = getattr(request_factory, method)(
             url, data=request_data, **request_kwargs
         )
+        request.resolver_match = resolve_view_match(self.view, url)
         if cookies is not None:
             request.COOKIES = dict(cookies)
 
@@ -105,7 +127,7 @@ class DjangoHttpClient(HttpClient):
 
 
 class AsyncDjangoHttpClient(HttpClient):
-    def __init__(self, view: Callable[[HttpRequest], Awaitable[HttpResponse]]) -> None:
+    def __init__(self, view: Callable[..., Awaitable[HttpResponse]]) -> None:
         self.view = view
 
     def _to_django_headers(self, headers: Mapping[str, str]) -> dict[str, str]:
@@ -152,7 +174,15 @@ class AsyncDjangoHttpClient(HttpClient):
 
     async def _do_request(self, request: HttpRequest) -> Response:
         try:
-            response = await self.view(request)
+            resolver_match = request.resolver_match
+            if resolver_match is None:
+                response = await self.view(request)
+            else:
+                response = await self.view(
+                    request,
+                    *resolver_match.args,
+                    **resolver_match.kwargs,
+                )
         except Http404:
             return Response(status_code=404, data=b"Not found")
         except (BadRequest, SuspiciousOperation) as exc:
@@ -198,6 +228,7 @@ class AsyncDjangoHttpClient(HttpClient):
         request = getattr(request_factory, method)(
             url, data=request_data, **request_kwargs
         )
+        request.resolver_match = resolve_view_match(self.view, url)
         if cookies is not None:
             request.COOKIES = dict(cookies)
 

--- a/tests/request/test_async_http_request.py
+++ b/tests/request/test_async_http_request.py
@@ -15,6 +15,7 @@ async def test_async_http_request_properties() -> None:
     adapter = TestingRequestAdapter(
         method="PUT",
         query_params={"q": "search"},
+        path_params={"user_id": "123"},
         headers={"Authorization": "Bearer token"},
         content_type="application/json",
         url="https://api.example.com/endpoint",
@@ -24,6 +25,7 @@ async def test_async_http_request_properties() -> None:
 
     assert request.method == "PUT"
     assert request.query_params == {"q": "search"}
+    assert request.path_params == {"user_id": "123"}
     assert request.headers == {"Authorization": "Bearer token"}
     assert request.content_type == "application/json"
     assert request.url == "https://api.example.com/endpoint"

--- a/tests/request/test_testing.py
+++ b/tests/request/test_testing.py
@@ -9,6 +9,7 @@ async def test_testing_request_adapter_defaults() -> None:
 
     assert adapter.method == "POST"
     assert adapter.query_params == {}
+    assert adapter.path_params == {}
     assert adapter.headers == {}
     assert adapter.content_type is None
     assert adapter.url == "http://testserver/"
@@ -27,6 +28,7 @@ async def test_testing_request_adapter_custom_values() -> None:
     adapter = TestingRequestAdapter(
         method="GET",
         query_params={"key": "value"},
+        path_params={"user_id": "123"},
         headers={"X-Custom": "header"},
         content_type="application/json",
         url="http://example.com/test",
@@ -36,6 +38,7 @@ async def test_testing_request_adapter_custom_values() -> None:
 
     assert adapter.method == "GET"
     assert adapter.query_params == {"key": "value"}
+    assert adapter.path_params == {"user_id": "123"}
     assert adapter.headers == {"X-Custom": "header"}
     assert adapter.content_type == "application/json"
     assert adapter.url == "http://example.com/test"

--- a/tests/testing/clients/builders.py
+++ b/tests/testing/clients/builders.py
@@ -46,6 +46,7 @@ def build_result(
     url = urlsplit(str(adapter.url))
     result: dict[str, object] = {
         "query_params": dict(adapter.query_params),
+        "path_params": dict(adapter.path_params),
         "method": adapter.method,
         "header_content_type": get_content_type(dict(adapter.headers)),
         "content_type": adapter.content_type,
@@ -94,7 +95,7 @@ def create_aiohttp_app() -> Any:
         return web.json_response(payload)
 
     app = web.Application()
-    app.router.add_post("/request", handler)
+    app.router.add_post("/request/{item_id}", handler)
     return app
 
 
@@ -105,8 +106,12 @@ def create_chalice_app() -> Any:
 
     app = Chalice(app_name="cross-web-testing")
 
-    @app.route("/request", methods=["POST"], content_types=["application/json"])
-    def handler() -> dict[str, object]:
+    @app.route(
+        "/request/{item_id}",
+        methods=["POST"],
+        content_types=["application/json"],
+    )
+    def handler(item_id: str) -> dict[str, object]:
         request = app.current_request
         assert request is not None
 
@@ -118,10 +123,11 @@ def create_chalice_app() -> Any:
 
 def create_django_view() -> Any:
     from django.http import HttpRequest, JsonResponse
+    from django.urls import path
 
     from cross_web.request._django import DjangoHTTPRequestAdapter
 
-    def view(request: HttpRequest) -> JsonResponse:
+    def view(request: HttpRequest, item_id: str) -> JsonResponse:
         adapter = DjangoHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -138,15 +144,17 @@ def create_django_view() -> Any:
 
         return JsonResponse(payload)
 
+    view._cross_web_urlpatterns = (path("request/<str:item_id>", view),)  # type: ignore[attr-defined]
     return view
 
 
 def create_async_django_view() -> Any:
     from django.http import HttpRequest, JsonResponse
+    from django.urls import path
 
     from cross_web.request._django import AsyncDjangoHTTPRequestAdapter
 
-    async def view(request: HttpRequest) -> JsonResponse:
+    async def view(request: HttpRequest, item_id: str) -> JsonResponse:
         adapter = AsyncDjangoHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -162,6 +170,7 @@ def create_async_django_view() -> Any:
 
         return JsonResponse(payload)
 
+    view._cross_web_urlpatterns = (path("request/<str:item_id>", view),)  # type: ignore[attr-defined]
     return view
 
 
@@ -172,8 +181,8 @@ def create_flask_app() -> Any:
 
     app = Flask(__name__)
 
-    @app.post("/request")
-    def handler() -> dict[str, object]:
+    @app.post("/request/<item_id>")
+    def handler(item_id: str) -> dict[str, object]:
         adapter = FlaskHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -198,8 +207,8 @@ def create_async_flask_app() -> Any:
 
     app = Flask(__name__)
 
-    @app.post("/request")
-    async def handler() -> dict[str, object]:
+    @app.post("/request/<item_id>")
+    async def handler(item_id: str) -> dict[str, object]:
         adapter = AsyncFlaskHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -221,8 +230,10 @@ def create_litestar_app() -> Any:
 
     from cross_web.request._litestar import LitestarRequestAdapter
 
-    @post("/request", status_code=200)
-    async def handler(request: Request[Any, Any, Any]) -> dict[str, object]:
+    @post("/request/{item_id:str}", status_code=200)
+    async def handler(
+        request: Request[Any, Any, Any], item_id: str
+    ) -> dict[str, object]:
         adapter = LitestarRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -246,8 +257,8 @@ def create_quart_app() -> Any:
 
     app = Quart(__name__)
 
-    @app.post("/request")
-    async def handler() -> dict[str, object]:
+    @app.post("/request/<item_id>")
+    async def handler(item_id: str) -> dict[str, object]:
         adapter = QuartHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -274,7 +285,7 @@ def create_sanic_app() -> Any:
 
     app = Sanic(f"CrossWeb_{uuid.uuid4().hex[:8]}")
 
-    async def handler(request: Request) -> JSONResponse:
+    async def handler(request: Request, item_id: str) -> JSONResponse:
         adapter = SanicHTTPRequestAdapter(request)
 
         if adapter.content_type == "application/json":
@@ -290,7 +301,7 @@ def create_sanic_app() -> Any:
 
         return sanic_json(payload)
 
-    app.add_route(handler, "/request", methods=["POST"])
+    app.add_route(handler, "/request/<item_id>", methods=["POST"])
     return app
 
 
@@ -318,4 +329,4 @@ def create_starlette_app() -> Any:
 
         return JSONResponse(payload)
 
-    return Starlette(routes=[Route("/request", handler, methods=["POST"])])
+    return Starlette(routes=[Route("/request/{item_id}", handler, methods=["POST"])])

--- a/tests/testing/clients/test_http_clients.py
+++ b/tests/testing/clients/test_http_clients.py
@@ -8,7 +8,7 @@ from cross_web.testing import HttpClient
 @pytest.mark.asyncio
 async def test_request_adapter_json(http_client: HttpClient) -> None:
     response = await http_client.post(
-        "/request?query=test",
+        "/request/abc?query=test",
         json={"key": "value"},
         cookies={"session": "123"},
     )
@@ -16,10 +16,11 @@ async def test_request_adapter_json(http_client: HttpClient) -> None:
 
     assert response.status_code == 200
     assert result["query_params"] == {"query": "test"}
+    assert result["path_params"] == {"item_id": "abc"}
     assert result["method"] == "POST"
     assert result["header_content_type"] == "application/json"
     assert result["content_type"] == "application/json"
-    assert result["url_path"] == "/request"
+    assert result["url_path"] == "/request/abc"
     assert result["url_query"] == "query=test"
     assert result["cookies"] == {"session": "123"}
     assert result["body_json"] == {"key": "value"}
@@ -31,7 +32,7 @@ async def test_request_adapter_form_data(http_client: HttpClient) -> None:
         pytest.skip("This framework adapter does not support form data")
 
     response = await http_client.post(
-        "/request?query=test",
+        "/request/abc?query=test",
         data={"form": "data"},
         files={"file": ("test.txt", b"upload", "text/plain")},
         cookies={"session": "123"},
@@ -43,12 +44,13 @@ async def test_request_adapter_form_data(http_client: HttpClient) -> None:
     content_type = cast(Optional[str], result["content_type"])
 
     assert result["query_params"] == {"query": "test"}
+    assert result["path_params"] == {"item_id": "abc"}
     assert result["method"] == "POST"
     assert header_content_type is not None
     assert header_content_type.startswith("multipart/form-data")
     assert content_type is not None
     assert content_type.startswith("multipart/form-data")
-    assert result["url_path"] == "/request"
+    assert result["url_path"] == "/request/abc"
     assert result["url_query"] == "query=test"
     assert result["cookies"] == {"session": "123"}
     assert result["form_value"] == "data"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path parameters from URL routes are now accessible through the request object across all supported frameworks (Django, Flask, Starlette, Litestar, Sanic, Chalice, Aiohttp, and Quart).
  * Testing clients now support path parameter injection and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->