### PR TITLE
Add sync HTTPRequest wrapper

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+---
+release type: minor
+---
+
+This release adds a synchronous `HTTPRequest` wrapper for sync request adapters.

--- a/src/cross_web/__init__.py
+++ b/src/cross_web/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import HTTPException
 from .protocols import BaseRequestProtocol
-from .request import AsyncHTTPRequest
+from .request import AsyncHTTPRequest, HTTPRequest
 from .request._aiohttp import AiohttpHTTPRequestAdapter
 from .request._base import AsyncHTTPRequestAdapter, FormData, SyncHTTPRequestAdapter
 from .request._chalice import ChaliceHTTPRequestAdapter
@@ -10,7 +10,7 @@ from .request._litestar import LitestarRequestAdapter
 from .request._quart import QuartHTTPRequestAdapter
 from .request._sanic import SanicHTTPRequestAdapter
 from .request._starlette import StarletteRequestAdapter
-from .request._testing import TestingRequestAdapter
+from .request._testing import TestingHTTPRequestAdapter, TestingRequestAdapter
 from .response import Cookie, Response
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "DjangoHTTPRequestAdapter",
     "FlaskHTTPRequestAdapter",
     "FormData",
+    "HTTPRequest",
     "HTTPException",
     "LitestarRequestAdapter",
     "QuartHTTPRequestAdapter",
@@ -32,5 +33,6 @@ __all__ = [
     "SanicHTTPRequestAdapter",
     "StarletteRequestAdapter",
     "SyncHTTPRequestAdapter",
+    "TestingHTTPRequestAdapter",
     "TestingRequestAdapter",
 ]

--- a/src/cross_web/request/__init__.py
+++ b/src/cross_web/request/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping, Optional, Any
+from typing import TYPE_CHECKING, Mapping, Optional, Any, Union
 
 from typing_extensions import Self
 
@@ -13,9 +13,94 @@ from ._base import (
     HTTPMethod,
     PathParams,
     QueryParams,
+    SyncHTTPRequestAdapter,
 )
 from ._starlette import StarletteRequestAdapter
-from ._testing import TestingRequestAdapter
+from ._testing import TestingHTTPRequestAdapter, TestingRequestAdapter
+
+
+class HTTPRequest:
+    def __init__(self, adapter: SyncHTTPRequestAdapter) -> None:
+        self._adapter = adapter
+
+    @classmethod
+    def from_django(cls, request: Any) -> Self:
+        from ._django import DjangoHTTPRequestAdapter
+
+        adapter = DjangoHTTPRequestAdapter(request)
+        return cls(adapter)
+
+    @classmethod
+    def from_flask(cls, request: Any) -> Self:
+        from ._flask import FlaskHTTPRequestAdapter
+
+        adapter = FlaskHTTPRequestAdapter(request)
+        return cls(adapter)
+
+    @classmethod
+    def from_chalice(cls, request: Any) -> Self:
+        from ._chalice import ChaliceHTTPRequestAdapter
+
+        adapter = ChaliceHTTPRequestAdapter(request)
+        return cls(adapter)
+
+    @classmethod
+    def from_form_data(cls, data: Mapping[str, str]) -> Self:
+        adapter = TestingHTTPRequestAdapter(
+            content_type="application/x-www-form-urlencoded",
+            post_data=data,
+        )
+        return cls(adapter)
+
+    @property
+    def method(self) -> HTTPMethod:
+        """The HTTP method of the request."""
+        return self._adapter.method
+
+    @property
+    def query_params(self) -> QueryParams:
+        """The query parameters of the request."""
+        return self._adapter.query_params
+
+    @property
+    def path_params(self) -> PathParams:
+        """The path parameters of the request."""
+        return self._adapter.path_params
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """The request headers (case-insensitive keys recommended)."""
+        return self._adapter.headers
+
+    @property
+    def content_type(self) -> Optional[str]:
+        """The 'Content-Type' header value, if present."""
+        return self._adapter.content_type
+
+    @property
+    def body(self) -> Union[str, bytes]:
+        """Return the raw request body as bytes or string."""
+        return self._adapter.body
+
+    @property
+    def post_data(self) -> Mapping[str, Union[str, bytes]]:
+        """Return parsed POST data."""
+        return self._adapter.post_data
+
+    @property
+    def files(self) -> Mapping[str, Any]:
+        """Return uploaded files from the request."""
+        return self._adapter.files
+
+    @property
+    def url(self) -> str:
+        """The URL of the request."""
+        return self._adapter.url
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        """The request cookies."""
+        return self._adapter.cookies
 
 
 class AsyncHTTPRequest:

--- a/src/cross_web/request/_testing.py
+++ b/src/cross_web/request/_testing.py
@@ -1,9 +1,88 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
-from ._base import AsyncHTTPRequestAdapter, FormData, HTTPMethod, QueryParams
+from ._base import (
+    AsyncHTTPRequestAdapter,
+    FormData,
+    HTTPMethod,
+    PathParams,
+    QueryParams,
+    SyncHTTPRequestAdapter,
+)
+
+
+class TestingHTTPRequestAdapter(SyncHTTPRequestAdapter):
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        method: HTTPMethod = "POST",
+        query_params: QueryParams | None = None,
+        path_params: PathParams | None = None,
+        headers: Mapping[str, str] | None = None,
+        content_type: str | None = None,
+        body: Union[str, bytes] = "",
+        post_data: Mapping[str, Union[str, bytes]] | None = None,
+        files: Mapping[str, Any] | None = None,
+        url: str = "http://testserver/",
+        cookies: Mapping[str, str] | None = None,
+    ) -> None:
+        self._method = method
+        self._query_params = query_params or {}
+        self._path_params = path_params or {}
+        self._headers = headers or {}
+        self._content_type = content_type
+        self._body = body
+        self._post_data = post_data or {}
+        self._files = files or {}
+        self._url = url
+        self._cookies = cookies or {}
+
+    @property
+    def method(self) -> HTTPMethod:
+        return self._method
+
+    @property
+    def query_params(self) -> QueryParams:
+        return self._query_params
+
+    @property
+    def path_params(self) -> PathParams:
+        return self._path_params
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._headers
+
+    @property
+    def content_type(self) -> Optional[str]:
+        return self._content_type
+
+    @property
+    def body(self) -> Union[str, bytes]:
+        return self._body
+
+    @property
+    def post_data(self) -> Mapping[str, Union[str, bytes]]:
+        return self._post_data
+
+    @property
+    def files(self) -> Mapping[str, Any]:
+        return self._files
+
+    def get_form_data(self) -> FormData:
+        return FormData(files=self._files, form=self._post_data)
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        return self._cookies
 
 
 class TestingRequestAdapter(AsyncHTTPRequestAdapter):

--- a/tests/request/test_http_request.py
+++ b/tests/request/test_http_request.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from cross_web import HTTPRequest, TestingHTTPRequestAdapter
+
+
+def test_http_request_properties() -> None:
+    adapter = TestingHTTPRequestAdapter(
+        method="PUT",
+        query_params={"q": "search"},
+        path_params={"user_id": "123"},
+        headers={"Authorization": "Bearer token"},
+        content_type="application/json",
+        body='{"ok": true}',
+        post_data={"name": "test"},
+        files={"upload": "file_content"},
+        url="https://api.example.com/endpoint",
+        cookies={"session_id": "xyz789"},
+    )
+    request = HTTPRequest(adapter)
+
+    assert request._adapter is adapter
+    assert request.method == "PUT"
+    assert request.query_params == {"q": "search"}
+    assert request.path_params == {"user_id": "123"}
+    assert request.headers == {"Authorization": "Bearer token"}
+    assert request.content_type == "application/json"
+    assert request.body == '{"ok": true}'
+    assert request.post_data == {"name": "test"}
+    assert request.files == {"upload": "file_content"}
+    assert request.url == "https://api.example.com/endpoint"
+    assert request.cookies == {"session_id": "xyz789"}
+
+
+def test_http_request_body_and_form_properties() -> None:
+    request = HTTPRequest(
+        TestingHTTPRequestAdapter(
+            body=b'{"ok": true}',
+            post_data={"name": "test", "value": "123"},
+            files={"upload": "file_content"},
+        )
+    )
+
+    assert request.body == b'{"ok": true}'
+    assert request.post_data == {"name": "test", "value": "123"}
+    assert request.files == {"upload": "file_content"}
+
+
+def test_from_form_data() -> None:
+    data = {"username": "john", "password": "secret"}
+
+    request = HTTPRequest.from_form_data(data)
+
+    assert request.method == "POST"
+    assert request.content_type == "application/x-www-form-urlencoded"
+    assert request.body == ""
+    assert request.post_data == data
+    assert request.files == {}
+
+
+def test_testing_http_request_adapter() -> None:
+    adapter = TestingHTTPRequestAdapter(
+        method="GET",
+        query_params={"q": "search"},
+        path_params={"user_id": "123"},
+        headers={"X-Custom": "header"},
+        content_type="text/plain",
+        body="raw body",
+        post_data={"field": "value"},
+        files={"upload": "file_content"},
+        url="https://example.com/test",
+        cookies={"session": "abc123"},
+    )
+    request = HTTPRequest(adapter)
+
+    assert request.method == "GET"
+    assert request.query_params == {"q": "search"}
+    assert request.path_params == {"user_id": "123"}
+    assert request.headers == {"X-Custom": "header"}
+    assert request.content_type == "text/plain"
+    assert request.body == "raw body"
+    assert request.post_data == {"field": "value"}
+    assert request.files == {"upload": "file_content"}
+    assert request.url == "https://example.com/test"
+    assert request.cookies == {"session": "abc123"}
+
+
+def test_from_django() -> None:
+    mock_request = Mock()
+    mock_request.method = "GET"
+    mock_request.GET.dict.return_value = {"q": "search"}
+    mock_request.resolver_match = Mock()
+    mock_request.resolver_match.kwargs = {"item_id": "123"}
+    mock_request.body = b""
+    mock_request.headers = {"X-Test": "value"}
+    mock_request.content_type = "application/json"
+    mock_request.build_absolute_uri.return_value = (
+        "https://example.com/items/123/?q=search"
+    )
+    mock_request.COOKIES = {"session": "abc123"}
+
+    request = HTTPRequest.from_django(mock_request)
+
+    assert isinstance(request, HTTPRequest)
+    assert request._adapter.__class__.__name__ == "DjangoHTTPRequestAdapter"
+    assert request.method == "GET"
+    assert request.url == "https://example.com/items/123/?q=search"
+    assert request.query_params == {"q": "search"}
+    assert request.path_params == {"item_id": "123"}
+    assert request.headers["X-Test"] == "value"
+    assert request.content_type == "application/json"
+    assert request.cookies == {"session": "abc123"}
+
+
+def test_from_flask() -> None:
+    mock_request = Mock()
+    mock_request.method = "POST"
+    mock_request.args.to_dict.return_value = {"q": "search"}
+    mock_request.view_args = {"item_id": "123"}
+    mock_request.data = b""
+    mock_request.headers = {"X-Test": "value"}
+    mock_request.form = {"field": "value"}
+    mock_request.files = {"upload": "file_content"}
+    mock_request.content_type = "application/x-www-form-urlencoded"
+    mock_request.url = "https://example.com/items/123/?q=search"
+    mock_request.cookies = {"session": "abc123"}
+
+    request = HTTPRequest.from_flask(mock_request)
+
+    assert isinstance(request, HTTPRequest)
+    assert request._adapter.__class__.__name__ == "FlaskHTTPRequestAdapter"
+    assert request.method == "POST"
+    assert request.url == "https://example.com/items/123/?q=search"
+    assert request.query_params == {"q": "search"}
+    assert request.path_params == {"item_id": "123"}
+    assert request.headers["X-Test"] == "value"
+    assert request.content_type == "application/x-www-form-urlencoded"
+    assert request.post_data == {"field": "value"}
+    assert request.files == {"upload": "file_content"}
+    assert request.cookies == {"session": "abc123"}
+
+
+def test_from_chalice() -> None:
+    mock_request = Mock()
+    mock_request.method = "GET"
+    mock_request.query_params = {"q": "search"}
+    mock_request.uri_params = {"item_id": "123"}
+    mock_request.raw_body = b""
+    mock_request.headers = {
+        "Content-Type": "application/json",
+        "Cookie": "session=abc123; theme=light",
+        "X-Test": "value",
+    }
+    mock_request.context = {
+        "domainName": "example.com",
+        "path": "/items/123",
+        "stage": "dev",
+    }
+
+    request = HTTPRequest.from_chalice(mock_request)
+
+    assert isinstance(request, HTTPRequest)
+    assert request._adapter.__class__.__name__ == "ChaliceHTTPRequestAdapter"
+    assert request.method == "GET"
+    assert request.url == "https://example.com/dev/items/123?q=search"
+    assert request.query_params == {"q": "search"}
+    assert request.path_params == {"item_id": "123"}
+    assert request.headers["X-Test"] == "value"
+    assert request.content_type == "application/json"
+    assert request.cookies == {"session": "abc123", "theme": "light"}


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#19** (`2026-05-19-add-sync-httprequest-wrapper`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Introduce a synchronous HTTPRequest wrapper and supporting testing adapter to unify sync request handling across frameworks.

New Features:
- Add HTTPRequest wrapper class for synchronous requests backed by SyncHTTPRequestAdapter implementations.
- Expose factory constructors on HTTPRequest for creating instances from Django, Flask, Chalice requests, and from raw form data.
- Introduce TestingHTTPRequestAdapter for constructing synchronous test requests in code and exporting it from the package API.

Tests:
- Add unit tests covering HTTPRequest behavior, framework-specific constructors, and the TestingHTTPRequestAdapter.